### PR TITLE
Fix slicing/concatenation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,15 @@ arrays = [np.random.rand(*shape) for _ in range(n)]
 df = pd.DataFrame({
     "x": np.arange(n),
     "tensor": TensorArray(arrays)
-))
+})
 
 df["same_tensor"] = pd.Series(arrays).astype("Tensor")  # also works
 
 df["tensor"].tensor.values  # shape (100, 2, 3) for direct data access
+
+# we can manipulate underlying ND array directly via the `tensor` accessor
+df2["tensor"].tensor.values[:, -1] *= 2
+
 df.to_parquet("test.parquet". engine="pyarrow")  # store each tensor as fixed-size binary blob
 ```
 

--- a/tensorpandas/base.py
+++ b/tensorpandas/base.py
@@ -153,6 +153,10 @@ class TensorArray(pdx.ExtensionArray):
     def _from_sequence(cls, scalars, dtype=None, copy=False):
         return cls(scalars)
 
+    @classmethod
+    def _concat_same_type(cls, to_concat):
+        return cls(np.concatenate([arr.data for arr in to_concat]))
+
     def isna(self):
         return np.any(np.isnan(self.data), axis=tuple(range(1, self.tensor_ndim)))
 

--- a/tensorpandas/base.py
+++ b/tensorpandas/base.py
@@ -121,6 +121,7 @@ class TensorArray(pdx.ExtensionArray):
                 self.data = data  # empty array
             else:
                 raise ValueError("Incompatible data found at TensorArray initialization") from e
+
     # Attributes
     @property
     def dtype(self):
@@ -192,13 +193,21 @@ class TensorAccessor:
             raise AttributeError("Can only use .tensor accessor with Tensor values")
 
     @property
+    def tensorarray(self):
+        return self._obj.values
+
+    @property
     def values(self):
-        return self._obj.values.data
+        return self.tensorarray.data
+
+    @property
+    def dtype(self):
+        return self.tensorarray.dtype
 
     @property
     def ndim(self):
-        return self._obj.tensor_ndim
+        return self.tensorarray.tensor_ndim
 
     @property
     def shape(self):
-        return self._obj.tensor_shape
+        return self.tensorarray.tensor_shape

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -52,3 +52,8 @@ def test_tensor_accessor(shape, ta, df):
     assert np.array_equal(df["tensor"].tensor.values, ta.data)
     assert df["tensor"].tensor.ndim == len(shape) + 1
     assert df["tensor"].tensor.shape == (n, *shape)
+
+
+def test_df_slice_concat(df):
+    new_df = pd.concat([df.iloc[: n // 2], df.iloc[n // 2 :]])
+    pd.testing.assert_frame_equal(new_df, df)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -50,3 +50,5 @@ def test_tensor_astype(ta, df):
 
 def test_tensor_accessor(shape, ta, df):
     assert np.array_equal(df["tensor"].tensor.values, ta.data)
+    assert df["tensor"].tensor.ndim == len(shape) + 1
+    assert df["tensor"].tensor.shape == (n, *shape)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,5 @@
+import pytest
+
 import numpy as np
 import pandas as pd
 
@@ -5,23 +7,46 @@ from tensorpandas import TensorArray
 
 
 n = 100
-shape = (2, 3)
-arrays = [np.random.rand(*shape) for _ in range(n)]
-ta = TensorArray(arrays)
-df = pd.DataFrame(dict(
-    x=np.arange(n),
-    array=arrays,
-    tensor=ta,
-))
 
 
-def test_tensor_array_values():
+@pytest.fixture(params=[0, 1, 2])
+def shape(request):
+    return (2, 3)[: request.param]
+
+
+@pytest.fixture(params=["single_array", "sequence_of_arrays"])
+def init_data_type(request):
+    return request.param
+
+
+@pytest.fixture
+def init_data(init_data_type, shape):
+    if init_data_type == "single_array":
+        return np.random.rand(n, *shape)
+    elif init_data_type == "sequence_of_arrays":
+        return [np.random.rand(*shape) for _ in range(n)]
+    else:
+        raise ValueError(f"Unknown data type: {init_data_type}")
+
+
+@pytest.fixture
+def ta(init_data):
+    return TensorArray(init_data)
+
+
+@pytest.fixture
+def df(init_data, ta):
+    df = pd.DataFrame(dict(x=np.arange(n), array=list(init_data), tensor=ta,))
+    return df
+
+
+def test_tensor_array_values(shape, ta):
     assert ta.data.shape == tuple([n, *shape])
 
 
-def test_tensor_astype():
+def test_tensor_astype(ta, df):
     assert all(df["array"].astype("Tensor") == ta)
 
 
-def test_tensor_accessor():
+def test_tensor_accessor(shape, ta, df):
     assert np.array_equal(df["tensor"].tensor.values, ta.data)


### PR DESCRIPTION
The `ExtensionArray` subclass needs to implement `_concat_same_type` to allow concatenating two dataframes or series containing the new type. Concatenation is also indirectly used in `DataFrame.__repr__()` etc.