### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,9 +14,9 @@ jobs:
 
     name: "${{ matrix.os }}: python==${{ matrix.python-version }}, pandas==${{ matrix.pandas-version }}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64


### PR DESCRIPTION
This PR updates GitHub actions as per [this blog post](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/), to get rid of the warnings emitted during CI.